### PR TITLE
Splittrigger

### DIFF
--- a/HttpTriggerContact.cs
+++ b/HttpTriggerContact.cs
@@ -17,7 +17,7 @@ namespace TigerStride.ContactSvc
     /// <summary>
     /// Implement the HttpTrigger for an Azure Function that responds to the POST of the contact form on the corporate homepage.
     /// </summary> 
-    public class HttpTriggerContact
+    public partial class HttpTriggerContact
     {
         private readonly ILogger<HttpTriggerContact> _logger;  // Serilogger
         private readonly IConfiguration _configuration;
@@ -44,11 +44,7 @@ namespace TigerStride.ContactSvc
                 {
                     throw new ArgumentNullException(nameof(_logger));
                 }
-                _logger.LogInformation("----------------Begin Contact Function. V.2.---------------");
-
-                // Log the incoming request data
-                _logger.LogInformation("Request Headers: {Headers}", req.Headers);
-                _logger.LogInformation("Request Content-Type: {ContentType}", req.ContentType);
+                _logger.LogInformation("----------------Begin Contact Function. -------------------");
 
                 // Check the expected header
                 string customHeader = req.Headers["X-Custom-Header"].ToString();
@@ -128,21 +124,6 @@ namespace TigerStride.ContactSvc
             finally
             {
                 _logger?.LogInformation("----------------End Contact Function.--------------------");
-            }
-        }
-
-        [Function("CheckHealth")]
-        public IActionResult CheckHealth([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req)
-        {
-            try
-            {
-                _logger.LogInformation("Health check requested.");
-                return new OkObjectResult(new { status = "Healthy" });
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Health check failed.");
-                return new StatusCodeResult(StatusCodes.Status500InternalServerError);
             }
         }
     }

--- a/HttpTriggerHealthCheck.cs
+++ b/HttpTriggerHealthCheck.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using ContactSvc.Dtos;
+// using MailKit.Net.Smtp;
+// using MimeKit;
+// using Microsoft.Identity.Client;
+using System.Threading.Tasks;
+//using MailKit.Security;
+using Microsoft.Extensions.Configuration;
+using ContactSvc.Settings;
+using ContactSvc.Data;
+
+namespace TigerStride.ContactSvc
+{
+    /// <summary>
+    /// Implement the HttpTrigger for an Azure Function that responds to the POST of the contact form on the corporate homepage.
+    /// </summary> 
+    public partial class HttpTriggerContact
+    {
+        [Function("CheckHealth")]
+        public IActionResult CheckHealth([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req)
+        {
+            try
+            {
+                _logger.LogInformation("Health check requested.");
+                return new OkObjectResult(new { status = "Healthy" });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Health check failed.");
+                return new StatusCodeResult(StatusCodes.Status500InternalServerError);
+            }
+        }
+    }
+}

--- a/HttpTriggerHealthCheck.cs
+++ b/HttpTriggerHealthCheck.cs
@@ -2,20 +2,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using ContactSvc.Dtos;
-// using MailKit.Net.Smtp;
-// using MimeKit;
-// using Microsoft.Identity.Client;
-using System.Threading.Tasks;
-//using MailKit.Security;
-using Microsoft.Extensions.Configuration;
-using ContactSvc.Settings;
-using ContactSvc.Data;
 
 namespace TigerStride.ContactSvc
 {
     /// <summary>
-    /// Implement the HttpTrigger for an Azure Function that responds to the POST of the contact form on the corporate homepage.
+    /// CheckHealth endpoint for the Contact Service.
     /// </summary> 
     public partial class HttpTriggerContact
     {


### PR DESCRIPTION
Split the trigger code into two partial classes for the ContactSvc and HealthCheck endpoints.
Set the standard for any future endpoints for ease of maintenance